### PR TITLE
Fix NotFound route

### DIFF
--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -20,11 +20,10 @@ const routes = [
     ...AuthRoutes,
     {
         path: "*",
-        component: <NotFound />
+        element: <NotFound />
     }
     // Add more routes as needed...
 ]
 
 const router = createBrowserRouter(routes);
-
 export default router;


### PR DESCRIPTION
## Summary
- switch `component` to `element` in wildcard route

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686e66d906fc83329ff19bfd85513fca