### PR TITLE
Load API config from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,19 @@ export default tseslint.config([
 ])
 ```
 
+## Environment Variables
+
+The API client requires the following environment variables:
+
+```
+VITE_API_URL=<your API base URL>
+VITE_API_TOKEN=<authentication token>
+```
+
+Create a `.env` file in the project root and populate these values. When not
+defined, the application falls back to relative URLs and will send requests
+without an authorization header.
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,9 +1,20 @@
 import axios from 'axios';
 
+const baseURL = import.meta.env.VITE_API_URL || '';
+const token = import.meta.env.VITE_API_TOKEN;
+
+if (!import.meta.env.VITE_API_URL) {
+    console.warn('VITE_API_URL environment variable is not set. Defaulting to relative URLs.');
+}
+
+if (!token) {
+    console.warn('VITE_API_TOKEN environment variable is not set. Requests will be sent without authentication.');
+}
+
 const api = axios.create({
-    baseURL: 'https://api.example.com/v1',
+    baseURL,
     headers: {
-        'Authorization': 'Bearer YOUR_API_TOKEN',
+        ...(token ? { 'Authorization': `Bearer ${token}` } : {}),
         'Content-Type': 'application/json',
     },
 });
@@ -11,5 +22,4 @@ const api = axios.create({
 api.interceptors.request.use(config => {
     return config;
 });
-
 export default api;


### PR DESCRIPTION
## Summary
- fetch API base URL and token from Vite environment variables
- warn when variables aren't defined
- document env vars in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686e671902588332b699b3b94d2147f0