### PR TITLE
Add Vitest setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ export default tseslint.config([
 ])
 ```
 
+## Running Tests
+
+To execute unit tests, run:
+
+```bash
+npm test
+```
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@radix-ui/react-slot": "^1.2.3",
@@ -36,6 +37,11 @@
     "tw-animate-css": "^1.3.5",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.35.1",
-    "vite": "^7.0.3"
+    "vite": "^7.0.3",
+    "vitest": "^1.5.0",
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/jest-dom": "^6.1.4",
+    "@testing-library/user-event": "^14.6.1",
+    "jsdom": "^22.0.0"
   }
 }

--- a/src/components/ui/button.test.tsx
+++ b/src/components/ui/button.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { Button } from './button'
+import { describe, it, expect } from 'vitest'
+
+describe('Button', () => {
+  it('renders with provided text', () => {
+    render(<Button>Click me</Button>)
+    expect(screen.getByRole('button')).toHaveTextContent('Click me')
+  })
+})

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -18,6 +18,7 @@
     "moduleDetection": "force",
     "noEmit": true,
     "jsx": "react-jsx",
+    "types": ["vite/client", "vitest/globals"],
 
     /* Linting */
     "strict": true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import path from 'path'
 import tailwindcss from '@tailwindcss/vite'
@@ -10,5 +10,9 @@ export default defineConfig({
     alias: {
       '@': path.resolve(__dirname,'src'),
     },
+  },
+  test: {
+    environment: 'jsdom',
+    globals: true,
   }
 })


### PR DESCRIPTION
## Summary
- configure Vitest in `vite.config.ts`
- add test dependencies and script to `package.json`
- set up Vitest types in `tsconfig.app.json`
- add example test for `Button` component
- document testing instructions in README

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e671e652c8332bf6237b0d74c9c19